### PR TITLE
Error handling added

### DIFF
--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,4 +1,3 @@
-import { Center, Text } from "@chakra-ui/react"
 import { useRouter } from "next/router"
 import { useEffect } from "react"
 import Layout from "../src/components/layout/layout"
@@ -6,7 +5,13 @@ import Layout from "../src/components/layout/layout"
 function Error({ statusCode }) {
   const router = useRouter()
   useEffect(() => {
-    router.push(`/error/${statusCode}`)
+    if (400 <= statusCode && statusCode < 500) {
+      router.push(`/error/${statusCode}`)
+    } else if (500 <= statusCode) {
+      router.push("/error/500")
+    } else {
+      router.push("/error/unknown")
+    }
     // eslint-disable-next-line
   }, [])
   return <Layout></Layout>

--- a/pages/error/[statusCode].tsx
+++ b/pages/error/[statusCode].tsx
@@ -9,7 +9,9 @@ const ErrorPage = () => {
     <Layout>
       <Center h="calc(100vh - 8rem)">
         <Text fontSize="4xl">
-          {query.statusCode ? query.statusCode : "Something bad has happened!"}
+          {query.statusCode === "unknown"
+            ? "Something bad has happened!"
+            : query.statusCode}
         </Text>
       </Center>
     </Layout>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "pages/_document.tsx", "pages/404.jsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "pages/_document.tsx", "pages/404.jsx", "src/components/global/ErrorBoundary.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
If error happens, page automatically redirected to the endpoint of..

1. 4xx -> `/error/${statusCode}`
![image](https://user-images.githubusercontent.com/38537908/182365050-a1dc5398-3bcc-4034-a8c8-5ae51d406b9d.png)
2. 5xx -> '/error/500`
3. Anything else higher than 400 is `/error/unknown`
![image](https://user-images.githubusercontent.com/38537908/182364985-7694cbf1-404e-472f-adae-bfa5baf0b03f.png)


and telemetry is being fired accordingly. Anything else is needed, plz let me know! 
