### PR TITLE
more accurate daily active parcel counts

### DIFF
--- a/src/components/local/change/changelog/changelog.ts
+++ b/src/components/local/change/changelog/changelog.ts
@@ -34,6 +34,12 @@ export const minorchangeTemplate = [
         title: "DAO Grant passed to fund dcl-metrics for one year!",
         description: `https://governance.decentraland.org/proposal/?id=ac2b57f0-12ac-11ed-affb-95d45c2147f8`,
       },
+      {
+        icon: FiTarget,
+        day: "2022 September",
+        title: "More accurate daily stats",
+        description: "By using multiple data streams, we are able to build a more accurate count of daily active parcels with data going back to 2022-08-22",
+      },
     ],
   },
 ]


### PR DESCRIPTION
i started using peer stats (the new endpoint that dcl made a few weeks ago) to calculate daily active parcels in daily stats: 

before (old calculation)

```
2022-08-23 5884
2022-08-24 6581
2022-08-25 6548
2022-08-26 6419
2022-08-27 5316
2022-08-28 5141
2022-08-29 5200
2022-08-30 5904
2022-08-31 5618
2022-09-01 5579
2022-09-02 5836
2022-09-03 5216
```

after (new calcuation)

```
2022-08-23 7531
2022-08-24 7867
2022-08-25 7749
2022-08-26 7537
2022-08-27 6893
2022-08-28 6638
2022-08-29 6851
2022-08-30 7562
2022-08-31 6658
2022-09-01 6404
2022-09-02 6505
2022-09-03 6095
```